### PR TITLE
Conside CREATING to be a final state for GSIs

### DIFF
--- a/provider/global_secondary_index.go
+++ b/provider/global_secondary_index.go
@@ -463,10 +463,10 @@ func waitDynamoDBGSIDeleted(c *dynamodb.DynamoDB, tn string, in string) error {
 func waitDynamoDBGSIActive(c *dynamodb.DynamoDB, tn string, in string) error {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{
-			dynamodb.IndexStatusCreating,
 			dynamodb.IndexStatusUpdating,
 		},
 		Target: []string{
+			dynamodb.IndexStatusCreating,
 			dynamodb.IndexStatusActive,
 		},
 		Timeout: createGSITimeout,


### PR DESCRIPTION
Creating an index can take a long time and we don't want Terraform to
wait for completion especially if other resources depend on it.

Fix verkada/terraform-provider-gsi#7