### PR TITLE
Specify the branch on which the gitaction is getting triggered

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,8 @@
 name: release
 on:
   push:
+    branches:
+      - main
     tags:
       - 'v*'
 jobs:


### PR DESCRIPTION
Per this [SO link](https://stackoverflow.com/questions/70749147/github-release-workflow-is-not-working-and-is-no-longer-running), the branch on which a github action is triggered should be specified. Example error [here](https://github.com/verkada/terraform-provider-gsi/actions/runs/4077546865/jobs/7026701388).