### PR TITLE
Set name & table_name on read

### DIFF
--- a/provider/global_secondary_index.go
+++ b/provider/global_secondary_index.go
@@ -323,6 +323,8 @@ func readGSI(d *schema.ResourceData, c *dynamodb.DynamoDB, tn string, in string)
 	}
 
 	d.Set("arn", i.IndexArn)
+	d.Set("name", i.IndexName)
+	d.Set("table_name", t.TableName)
 
 	// Since readGSI can be used on an import on create, we need to erase the optional values from the
 	// state or we will end up with writing a state that is the expected one rather than the applied one


### PR DESCRIPTION
This prevents Terraform from trying to recreate the table after import:

```
  # gsi_global_secondary_index.this must be replaced
-/+ resource "gsi_global_secondary_index" "this" {
      ~ arn                 = ...
      + autoscaling_enabled = false
      + billing_mode        = "PAY_PER_REQUEST"
      ~ id                  = "mytable:myindex" -> (known after apply)
      + name                = "myindex" # forces replacement
      - read_capacity       = 0 -> null
      + table_name          = "mytable" # forces replacement
      - write_capacity      = 0 -> null
        # (6 unchanged attributes hidden)
    }
```