### PR TITLE
Fix parsing error when using assume_role

### DIFF
--- a/provider/provider.go
+++ b/provider/provider.go
@@ -153,13 +153,12 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	profile := d.Get("profile").(string)
 	region := d.Get("region").(string)
 	endpoint := d.Get("dynamodb_endpoint").(string)
-	assume_role_config := d.Get("assume_role").([]interface{})
+	assume_role_config := d.Get("assume_role").(map[string]interface{})
 	validate := d.Get("validate").(bool)
 
 	role_arn := ""
 	if len(assume_role_config) > 0 {
-		configmap := assume_role_config[0].(map[string]interface{})
-		if v, ok := configmap["role_arn"].(string); ok && v != "" {
+		if v, ok := assume_role_config["role_arn"].(string); ok && v != "" {
 			role_arn = v
 		}
 	}


### PR DESCRIPTION
Fix the following error
```
╷
│ Error: Plugin did not respond
│ 
│   with provider["registry.terraform.io/verkada/gsi"],
│   on backend.tf line 71, in provider "gsi":
│   71: provider "gsi" {
│ 
│ The plugin encountered an error, and failed to respond to the plugin.(*GRPCProvider).ConfigureProvider call. The plugin logs
│ may contain more details.
╵

Stack trace from the terraform-provider-gsi_v0.5.0 plugin:

panic: interface conversion: interface {} is nil, not map[string]interface {}

goroutine 24 [running]:
terraform-provider-gsi/provider.providerConfigure(0x14000556700)
        terraform-provider-gsi/provider/provider.go:161 +0x470
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Provider).Configure(0x140005aa5f0, {0x103d27330, 0x1400056b5c0}, 0x1400056b410)
        github.com/hashicorp/terraform-plugin-sdk/v2@v2.8.0/helper/schema/provider.go:279 +0x1c0
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*GRPCProviderServer).ConfigureProvider(0x1400000c2e8, {0x103d27288, 0x140003a30c0}, 0x1400072e6a8)
        github.com/hashicorp/terraform-plugin-sdk/v2@v2.8.0/helper/schema/grpc_provider.go:523 +0x33c
github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server.(*server).Configure(0x140005a5120, {0x103d27330, 0x1400056acc0}, 0x140003a3080)
        github.com/hashicorp/terraform-plugin-go@v0.4.0/tfprotov5/tf5server/server.go:182 +0x168
github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5._Provider_Configure_Handler({0x103cbf1a0, 0x140005a5120}, {0x103d27330, 0x1400056acc0}, 0x1400012ed80, 0x0)
        github.com/hashicorp/terraform-plugin-go@v0.4.0/tfprotov5/internal/tfplugin5/tfplugin5_grpc.pb.go:326 +0x1c0
google.golang.org/grpc.(*Server).processUnaryRPC(0x140000b7dc0, {0x103d36850, 0x14000314780}, 0x14000552200, 0x140007297a0, 0x1043bed58, 0x0)
        google.golang.org/grpc@v1.36.0/server.go:1217 +0xc38
google.golang.org/grpc.(*Server).handleStream(0x140000b7dc0, {0x103d36850, 0x14000314780}, 0x14000552200, 0x0)
        google.golang.org/grpc@v1.36.0/server.go:1540 +0xa34
google.golang.org/grpc.(*Server).serveStreams.func1.2(0x14000035a20, 0x140000b7dc0, {0x103d36850, 0x14000314780}, 0x14000552200)
        google.golang.org/grpc@v1.36.0/server.go:878 +0x94
created by google.golang.org/grpc.(*Server).serveStreams.func1
        google.golang.org/grpc@v1.36.0/server.go:876 +0x1f0

Error: The terraform-provider-gsi_v0.5.0 plugin crashed!

This is always indicative of a bug within the plugin. It would be immensely
helpful if you could report the crash with the plugin's maintainers so that it
can be fixed. The output above should help diagnose the issue.```