### PR TITLE
support nil assume role reference

### DIFF
--- a/provider/provider.go
+++ b/provider/provider.go
@@ -157,7 +157,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	validate := d.Get("validate").(bool)
 
 	role_arn := ""
-	if len(assume_role_config) > 0 {
+	if len(assume_role_config) > 0 && assume_role_config[0] != nil {
 		configmap := assume_role_config[0].(map[string]interface{})
 		if v, ok := configmap["role_arn"].(string); ok && v != "" {
 			role_arn = v


### PR DESCRIPTION
It appears that passing:
```
assume_role {
  role_arn = ""
}
```
will lead to a {nil} in the config (`assume_role`) leading to:
```
terraform-provider-gsi/provider.providerConfigure(0xee9113)
	terraform-provider-gsi/provider/provider.go:161 +0x3f6
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Provider).Configure(0xc00065c640, {0x11f5e70, 0xc0009ef080}, 0xc00070c5b0)
	github.com/hashicorp/terraform-plugin-sdk/v2@v2.8.0/helper/schema/provider.go:279 +0x19c
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*GRPCProviderServer).ConfigureProvider(0xc00000d170, {0x11f5dc8, 0xc0006586c0}, 0xc00039c0f0)
	github.com/hashicorp/terraform-plugin-sdk/v2@v2.8.0/helper/schema/grpc_provider.go:523 +0x27b
github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server.(*server).Configure(0xc000561200, {0x11f5e70, 0xc0003799b0}, 0xc000658400)
	github.com/hashicorp/terraform-plugin-go@v0.4.0/tfprotov5/tf5server/server.go:182 +0x142
github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5._Provider_Configure_Handler({0xead1e0, 0xc000561200}, {0x11f5e70, 0xc0003799b0}, 0xc000654540, 0x0)
	github.com/hashicorp/terraform-plugin-go@v0.4.0/tfprotov5/internal/tfplugin5/tfplugin5_grpc.pb.go:326 +0x170
google.golang.org/grpc.(*Server).processUnaryRPC(0xc0003a2000, {0x12069b0, 0xc0008bc000}, 0xc00011e200, 0xc000348f90, 0x18b2db8, 0x0)
	google.golang.org/grpc@v1.36.0/server.go:1217 +0xc8f
google.golang.org/grpc.(*Server).handleStream(0xc0003a2000, {0x12069b0, 0xc0008bc000}, 0xc00011e200, 0x0)
	google.golang.org/grpc@v1.36.0/server.go:1540 +0xa2a
google.golang.org/grpc.(*Server).serveStreams.func1.2()
	google.golang.org/grpc@v1.36.0/server.go:878 +0x98
created by google.golang.org/grpc.(*Server).serveStreams.func1
	google.golang.org/grpc@v1.36.0/server.go:876 +0x294
```